### PR TITLE
refactor: change id from i64 to string and clone to to_owned

### DIFF
--- a/crates/ruline-action/src/lib.rs
+++ b/crates/ruline-action/src/lib.rs
@@ -19,7 +19,7 @@ pub enum ActionDefinition {
 #[derive(Debug)]
 pub struct Action {
     pub definition: ActionDefinition,
-    pub dependencies: Vec<i64>,
+    pub dependencies: Vec<String>,
 }
 
 impl TryFrom<ActionDefinition> for Action {
@@ -52,14 +52,14 @@ impl Action {
         match &self.definition {
             ActionDefinition::SetVariable { variable, value } => {
                 let field = Field::from(value);
-                ctx.set_variable(variable.clone(), field.process(ctx)?);
+                ctx.set_variable(variable.to_owned(), field.process(ctx)?);
             }
         }
 
         Ok(())
     }
 
-    pub fn dependencies(&self) -> Vec<i64> {
-        self.dependencies.clone()
+    pub fn dependencies(&self) -> Vec<String> {
+        self.dependencies.to_owned()
     }
 }

--- a/crates/ruline-action/tests/set_variable.rs
+++ b/crates/ruline-action/tests/set_variable.rs
@@ -83,11 +83,11 @@ fn test_set_variable_dependencies() {
         "variable": "key",
         "value": {
             "type": "output",
-            "output_id": 20,
+            "output_id": "20",
             "path": "/key"
         }
     });
 
     let action = Action::try_from(definition).unwrap();
-    assert_eq!(action.dependencies(), vec![20]);
+    assert_eq!(action.dependencies(), vec!["20"]);
 }

--- a/crates/ruline-condition/benches/mod.rs
+++ b/crates/ruline-condition/benches/mod.rs
@@ -13,122 +13,112 @@ pub fn benchmark(c: &mut Criterion) {
        "id":1,
        "name":"complex_nested",
        "fallbacks":[
-          0
+          "0"
        ],
        "results":{
           "100":[
-             1
+             "1"
           ],
           "300":[
-             2
+             "2"
           ]
        },
        "expressions":[
           {
-             "id":300,
+             "id":"300",
              "type":"logical",
              "operator":"and",
              "expressions":[
                 {
-                   "id":301,
+                   "id":"301",
                    "type":"logical",
                    "operator":"and",
                    "expressions":[
                       {
-                         "id":302,
+                         "id":"302",
                          "type":"comparison",
                          "operator":"greater_than",
                          "operands":[
                             {
                                "type":"data",
-                               "id":7,
                                "name":"first_value",
                                "path":"/first_value"
                             },
                             {
                                "type":"value",
-                               "id":8,
                                "name":"value",
                                "value":40
                             }
                          ]
                       },
                       {
-                         "id":303,
+                         "id":"303",
                          "type":"comparison",
                          "operator":"less_than",
                          "operands":[
                             {
                                "type":"data",
-                               "id":9,
                                "name":"second_value",
                                "path":"/second_value"
                             },
                             {
                                "type":"value",
-                               "id":10,
                                "name":"value",
                                "value":40
                             }
                          ]
                       },
                       {
-                         "id":304,
+                         "id":"304",
                          "type":"comparison",
                          "operator":"equals",
                          "operands":[
                             {
                                "type":"data",
-                               "id":9,
                                "name":"second_value",
                                "path":"/second_value"
                             },
                             {
                                "type":"value",
-                               "id":10,
                                "name":"value",
                                "value":30
                             }
                          ]
                       },
                       {
-                          "id": 305,
+                          "id": "305",
                           "type": "logical",
                           "operator": "or",
                           "expressions": [
                               {
-                                  "id": 306,
+                                  "id": "306",
                                   "type": "comparison",
                                   "operator": "equals",
                                   "operands": [
                                       {
                                           "type": "data",
-                                          "id": 11,
                                           "name": "first_value",
                                           "path": "/first_value"
                                       },
                                       {
                                           "type": "value",
-                                          "id": 12,
                                           "name": "value",
                                           "value": 42
                                       }
                                   ]
                               },
                               {
-                                  "id": 307,
+                                  "id": "307",
                                   "type": "comparison",
                                   "operator": "equals",
                                   "operands": [
                                       {
                                           "type": "data",
-                                          "id": 13,
                                           "name": "second_value",
                                           "path": "/second_value"
                                       },
                                       {
                                           "type": "value",
-                                          "id": 14,
                                           "name": "value",
                                           "value": 30
                                       }
@@ -139,67 +129,61 @@ pub fn benchmark(c: &mut Criterion) {
                    ]
                 },
                 {
-                   "id":304,
+                   "id":"304",
                    "type":"logical",
                    "operator":"or",
                    "expressions":[
                       {
-                         "id":305,
+                         "id":"305",
                          "type":"comparison",
                          "operator":"greater_than",
                          "operands":[
                             {
                                "type":"data",
-                               "id":11,
                                "name":"first_value",
                                "path":"/first_value"
                             },
                             {
                                "type":"value",
-                               "id":12,
                                "name":"value",
                                "value":50
                             }
                          ]
                       },
                       {
-                         "id":306,
+                         "id":"306",
                          "type":"logical",
                          "operator":"and",
                          "expressions":[
                             {
-                               "id":307,
+                               "id":"307",
                                "type":"comparison",
                                "operator":"less_than",
                                "operands":[
                                   {
                                      "type":"data",
-                                     "id":13,
                                      "name":"second_value",
                                      "path":"/second_value"
                                   },
                                   {
                                      "type":"value",
-                                     "id":14,
                                      "name":"value",
                                      "value":50
                                   }
                                ]
                             },
                             {
-                               "id":308,
+                               "id":"308",
                                "type":"comparison",
                                "operator":"greater_than",
                                "operands":[
                                   {
                                      "type":"data",
-                                     "id":15,
                                      "name":"second_value",
                                      "path":"/second_value"
                                   },
                                   {
                                      "type":"value",
-                                     "id":16,
                                      "name":"value",
                                      "value":20
                                   }
@@ -213,110 +197,100 @@ pub fn benchmark(c: &mut Criterion) {
           }
 ,
           {
-             "id":300,
+             "id":"300",
              "type":"logical",
              "operator":"and",
              "expressions":[
                 {
-                   "id":301,
+                   "id":"301",
                    "type":"logical",
                    "operator":"and",
                    "expressions":[
                       {
-                         "id":302,
+                         "id":"302",
                          "type":"comparison",
                          "operator":"greater_than",
                          "operands":[
                             {
                                "type":"data",
-                               "id":7,
                                "name":"first_value",
                                "path":"/first_value"
                             },
                             {
                                "type":"value",
-                               "id":8,
                                "name":"value",
                                "value":40
                             }
                          ]
                       },
                       {
-                         "id":303,
+                         "id":"303",
                          "type":"comparison",
                          "operator":"less_than",
                          "operands":[
                             {
                                "type":"data",
-                               "id":9,
                                "name":"second_value",
                                "path":"/second_value"
                             },
                             {
                                "type":"value",
-                               "id":10,
                                "name":"value",
                                "value":40
                             }
                          ]
                       },
                       {
-                         "id":304,
+                         "id":"304",
                          "type":"comparison",
                          "operator":"equals",
                          "operands":[
                             {
                                "type":"data",
-                               "id":9,
                                "name":"second_value",
                                "path":"/second_value"
                             },
                             {
                                "type":"value",
-                               "id":10,
                                "name":"value",
                                "value":30
                             }
                          ]
                       },
                       {
-                          "id": 305,
+                          "id": "305",
                           "type": "logical",
                           "operator": "or",
                           "expressions": [
                               {
-                                  "id": 306,
+                                  "id": "306",
                                   "type": "comparison",
                                   "operator": "equals",
                                   "operands": [
                                       {
                                           "type": "data",
-                                          "id": 11,
                                           "name": "first_value",
                                           "path": "/first_value"
                                       },
                                       {
                                           "type": "value",
-                                          "id": 12,
                                           "name": "value",
                                           "value": 42
                                       }
                                   ]
                               },
                               {
-                                  "id": 307,
+                                  "id": "307",
                                   "type": "comparison",
                                   "operator": "equals",
                                   "operands": [
                                       {
                                           "type": "data",
-                                          "id": 13,
                                           "name": "second_value",
                                           "path": "/second_value"
                                       },
                                       {
                                           "type": "value",
-                                          "id": 14,
                                           "name": "value",
                                           "value": 30
                                       }
@@ -327,67 +301,61 @@ pub fn benchmark(c: &mut Criterion) {
                    ]
                 },
                 {
-                   "id":304,
+                   "id":"304",
                    "type":"logical",
                    "operator":"or",
                    "expressions":[
                       {
-                         "id":305,
+                         "id":"305",
                          "type":"comparison",
                          "operator":"greater_than",
                          "operands":[
                             {
                                "type":"data",
-                               "id":11,
                                "name":"first_value",
                                "path":"/first_value"
                             },
                             {
                                "type":"value",
-                               "id":12,
                                "name":"value",
                                "value":50
                             }
                          ]
                       },
                       {
-                         "id":306,
+                         "id":"306",
                          "type":"logical",
                          "operator":"and",
                          "expressions":[
                             {
-                               "id":307,
+                               "id":"307",
                                "type":"comparison",
                                "operator":"less_than",
                                "operands":[
                                   {
                                      "type":"data",
-                                     "id":13,
                                      "name":"second_value",
                                      "path":"/second_value"
                                   },
                                   {
                                      "type":"value",
-                                     "id":14,
                                      "name":"value",
                                      "value":50
                                   }
                                ]
                             },
                             {
-                               "id":308,
+                               "id":"308",
                                "type":"comparison",
                                "operator":"greater_than",
                                "operands":[
                                   {
                                      "type":"data",
-                                     "id":15,
                                      "name":"second_value",
                                      "path":"/second_value"
                                   },
                                   {
                                      "type":"value",
-                                     "id":16,
                                      "name":"value",
                                      "value":20
                                   }

--- a/crates/ruline-condition/src/error.rs
+++ b/crates/ruline-condition/src/error.rs
@@ -9,9 +9,9 @@ pub enum ConditionError {
     #[error(
         "Children count for logical with id `{id}` is invalid, must be at least 2 and is {childrens_count}"
     )]
-    LogicalChildrenCountInvalid { id: i64, childrens_count: usize },
+    LogicalChildrenCountInvalid { id: String, childrens_count: usize },
     #[error("Comparison with id `{0}` must not have any children")]
-    ComparisonChildrenInvalid(i64),
+    ComparisonChildrenInvalid(String),
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
 }

--- a/crates/ruline-condition/tests/comparison.rs
+++ b/crates/ruline-condition/tests/comparison.rs
@@ -12,14 +12,14 @@ use serde_json::json;
 fn test_greater_than() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "greater_than",
                 "operands": [{
@@ -30,7 +30,7 @@ fn test_greater_than() {
                     "value": 40
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "greater_than",
                 "operands": [{
@@ -41,7 +41,7 @@ fn test_greater_than() {
                     "value": 0.004
                 }]
             }, {
-                "id": 304,
+                "id": "304",
                 "type": "comparison",
                 "operator": "greater_than",
                 "operands": [{
@@ -52,7 +52,7 @@ fn test_greater_than() {
                     "value": "abcc"
                 }]
             }, {
-                "id": 305,
+                "id": "305",
                 "type": "comparison",
                 "operator": "greater_than",
                 "operands": [{
@@ -65,21 +65,21 @@ fn test_greater_than() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_less_than() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "less_than",
                 "operands": [{
@@ -90,7 +90,7 @@ fn test_less_than() {
                     "value": 40
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "less_than",
                 "operands": [{
@@ -101,7 +101,7 @@ fn test_less_than() {
                     "value": 0.00344
                 }]
             }, {
-                "id": 304,
+                "id": "304",
                 "type": "comparison",
                 "operator": "less_than",
                 "operands": [{
@@ -112,7 +112,7 @@ fn test_less_than() {
                     "value": "zzzy"
                 }]
             }, {
-                "id": 305,
+                "id": "305",
                 "type": "comparison",
                 "operator": "less_than",
                 "operands": [{
@@ -125,21 +125,21 @@ fn test_less_than() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_equals() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "equals",
                 "operands": [{
@@ -150,7 +150,7 @@ fn test_equals() {
                     "value": 30
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "equals",
                 "operands": [{
@@ -161,7 +161,7 @@ fn test_equals() {
                     "value": "foo"
                 }]
             }, {
-                "id": 304,
+                "id": "304",
                 "type": "comparison",
                 "operator": "equals",
                 "operands": [{
@@ -172,7 +172,7 @@ fn test_equals() {
                     "value": [ "foo", "bar" ]
                 }]
             }, {
-                "id": 305,
+                "id": "305",
                 "type": "comparison",
                 "operator": "equals",
                 "operands": [{
@@ -183,7 +183,7 @@ fn test_equals() {
                     "value": { "foo": "bar" }
                 }]
             }, {
-                "id": 306,
+                "id": "306",
                 "type": "comparison",
                 "operator": "equals",
                 "operands": [{
@@ -194,7 +194,7 @@ fn test_equals() {
                     "value": true
                 }]
             }, {
-                "id": 307,
+                "id": "307",
                 "type": "comparison",
                 "operator": "equals",
                 "operands": [{
@@ -208,21 +208,21 @@ fn test_equals() {
             ]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_not_equals() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "not_equals",
                 "operands": [{
@@ -233,7 +233,7 @@ fn test_not_equals() {
                     "value": 40
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "not_equals",
                 "operands": [{
@@ -244,7 +244,7 @@ fn test_not_equals() {
                     "value": 30
                 }]
             }, {
-                "id": 304,
+                "id": "304",
                 "type": "comparison",
                 "operator": "not_equals",
                 "operands": [{
@@ -255,7 +255,7 @@ fn test_not_equals() {
                     "value": "bar"
                 }]
             }, {
-                "id": 305,
+                "id": "305",
                 "type": "comparison",
                 "operator": "not_equals",
                 "operands": [{
@@ -266,7 +266,7 @@ fn test_not_equals() {
                     "value": [ "foo", "bar" ]
                 }]
             }, {
-                "id": 306,
+                "id": "306",
                 "type": "comparison",
                 "operator": "not_equals",
                 "operands": [{
@@ -280,21 +280,21 @@ fn test_not_equals() {
             ]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_greater_than_or_equal() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "greater_than_or_equal",
                 "operands": [{
@@ -305,7 +305,7 @@ fn test_greater_than_or_equal() {
                     "value": 40
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "greater_than_or_equal",
                 "operands": [{
@@ -316,7 +316,7 @@ fn test_greater_than_or_equal() {
                     "value": 50
                 }]
             }, {
-                "id": 304,
+                "id": "304",
                 "type": "comparison",
                 "operator": "greater_than_or_equal",
                 "operands": [{
@@ -327,7 +327,7 @@ fn test_greater_than_or_equal() {
                     "value": "foo"
                 }]
             }, {
-                "id": 305,
+                "id": "305",
                 "type": "comparison",
                 "operator": "greater_than_or_equal",
                 "operands": [{
@@ -340,21 +340,21 @@ fn test_greater_than_or_equal() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_less_than_or_equal() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "less_than_or_equal",
                 "operands": [{
@@ -365,7 +365,7 @@ fn test_less_than_or_equal() {
                     "value": 40
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "less_than_or_equal",
                 "operands": [{
@@ -376,7 +376,7 @@ fn test_less_than_or_equal() {
                     "value": 21
                 }]
             }, {
-                "id": 304,
+                "id": "304",
                 "type": "comparison",
                 "operator": "less_than_or_equal",
                 "operands": [{
@@ -387,7 +387,7 @@ fn test_less_than_or_equal() {
                     "value": "foo"
                 }]
             }, {
-                "id": 305,
+                "id": "305",
                 "type": "comparison",
                 "operator": "less_than_or_equal",
                 "operands": [{
@@ -400,21 +400,21 @@ fn test_less_than_or_equal() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_contains() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "contains",
                 "operands": [{
@@ -425,7 +425,7 @@ fn test_contains() {
                     "value": ["foo", "bar"]
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "contains",
                 "operands": [{
@@ -438,21 +438,21 @@ fn test_contains() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_not_contains() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "not_contains",
                 "operands": [{
@@ -463,7 +463,7 @@ fn test_not_contains() {
                     "value": ["foo", "bar"]
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "not_contains",
                 "operands": [{
@@ -476,21 +476,21 @@ fn test_not_contains() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_not_exists() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "not_exists",
                 "operands": [{
@@ -498,7 +498,7 @@ fn test_not_exists() {
                     "value": null
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "not_exists",
                 "operands": [{
@@ -508,21 +508,21 @@ fn test_not_exists() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_exists() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "exists",
                 "operands": [{
@@ -539,7 +539,7 @@ fn test_exists() {
                     "value": true
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "exists",
                 "operands": [{
@@ -549,21 +549,21 @@ fn test_exists() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_empty() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "empty",
                 "operands": [{
@@ -571,7 +571,7 @@ fn test_empty() {
                     "value": []
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "empty",
                 "operands": [{
@@ -579,7 +579,7 @@ fn test_empty() {
                     "value": ""
                 }]
             }, {
-                "id": 304,
+                "id": "304",
                 "type": "comparison",
                 "operator": "empty",
                 "operands": [{
@@ -587,7 +587,7 @@ fn test_empty() {
                     "value": {}
                 }]
             }, {
-                "id": 305,
+                "id": "305",
                 "type": "comparison",
                 "operator": "empty",
                 "operands": [{
@@ -597,21 +597,21 @@ fn test_empty() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_not_empty() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "not_empty",
                 "operands": [{
@@ -619,7 +619,7 @@ fn test_not_empty() {
                     "value": ["foo"]
                 }]
             }, {
-                "id": 303,
+                "id": "303",
                 "type": "comparison",
                 "operator": "not_empty",
                 "operands": [{
@@ -629,17 +629,17 @@ fn test_not_empty() {
             }]
         }
     });
-    assert_comparison!(definition, vec![1]);
+    assert_comparison!(definition, vec!["1"]);
 }
 
 #[test]
 fn test_equals_operands_amount_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "equals",
             "operands": [{
@@ -655,10 +655,10 @@ fn test_equals_operands_amount_invalid() {
 fn test_greater_than_operands_amount_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "greater_than",
             "operands": [{
@@ -680,10 +680,10 @@ fn test_greater_than_operands_amount_invalid() {
 fn test_greater_than_operands_empty() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "greater_than",
             "operands": []
@@ -696,10 +696,10 @@ fn test_greater_than_operands_empty() {
 fn test_greater_than_operand_types_mismatch() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "greater_than",
             "operands": [{
@@ -719,10 +719,10 @@ fn test_greater_than_operand_types_mismatch() {
 fn test_greater_than_operand_type_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "greater_than",
             "operands": [{
@@ -742,10 +742,10 @@ fn test_greater_than_operand_type_invalid() {
 fn test_greater_than_or_equal_operands_amount_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "greater_than_or_equal",
             "operands": [{
@@ -767,10 +767,10 @@ fn test_greater_than_or_equal_operands_amount_invalid() {
 fn test_greater_than_or_equal_operands_empty() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "greater_than_or_equal",
             "operands": []
@@ -783,10 +783,10 @@ fn test_greater_than_or_equal_operands_empty() {
 fn test_greater_than_or_equal_operand_types_mismatch() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "greater_than_or_equal",
             "operands": [{
@@ -806,10 +806,10 @@ fn test_greater_than_or_equal_operand_types_mismatch() {
 fn test_greater_than_or_equal_operand_type_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "greater_than_or_equal",
             "operands": [{
@@ -829,10 +829,10 @@ fn test_greater_than_or_equal_operand_type_invalid() {
 fn test_less_than_operands_amount_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "less_than",
             "operands": [{
@@ -855,10 +855,10 @@ fn test_less_than_operands_amount_invalid() {
 fn test_less_than_operands_empty() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "less_than",
             "operands": []
@@ -871,10 +871,10 @@ fn test_less_than_operands_empty() {
 fn test_less_than_operand_types_mismatch() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "less_than",
             "operands": [{
@@ -894,10 +894,10 @@ fn test_less_than_operand_types_mismatch() {
 fn test_less_than_operand_type_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "less_than",
             "operands": [{
@@ -917,10 +917,10 @@ fn test_less_than_operand_type_invalid() {
 fn test_less_than_or_equal_operands_amount_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "less_than_or_equal",
             "operands": [{
@@ -943,10 +943,10 @@ fn test_less_than_or_equal_operands_amount_invalid() {
 fn test_less_than_or_equal_operands_empty() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "less_than_or_equal",
             "operands": []
@@ -959,10 +959,10 @@ fn test_less_than_or_equal_operands_empty() {
 fn test_less_than_or_equal_operand_types_mismatch() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "less_than_or_equal",
             "operands": [{
@@ -982,10 +982,10 @@ fn test_less_than_or_equal_operand_types_mismatch() {
 fn test_less_than_or_equal_operand_type_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "less_than_or_equal",
             "operands": [{
@@ -1005,10 +1005,10 @@ fn test_less_than_or_equal_operand_type_invalid() {
 fn test_empty_operands_amount_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "empty",
             "operands": [{
@@ -1028,10 +1028,10 @@ fn test_empty_operands_amount_invalid() {
 fn test_empty_operands_empty() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "empty",
             "operands": []
@@ -1044,10 +1044,10 @@ fn test_empty_operands_empty() {
 fn test_contains_operands_amount_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "contains",
             "operands": [{
@@ -1063,10 +1063,10 @@ fn test_contains_operands_amount_invalid() {
 fn test_contains_operands_empty() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "contains",
             "operands": []
@@ -1079,10 +1079,10 @@ fn test_contains_operands_empty() {
 fn test_contains_operand_type_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "contains",
             "operands": [{
@@ -1102,10 +1102,10 @@ fn test_contains_operand_type_invalid() {
 fn test_exists_operands_amount_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 302,
+            "id": "302",
             "type": "comparison",
             "operator": "exists",
             "operands": []

--- a/crates/ruline-condition/tests/condition.rs
+++ b/crates/ruline-condition/tests/condition.rs
@@ -20,22 +20,16 @@ fn test_decision_complex_nested_all_passed() {
     let mut deserializer = serde_json::Deserializer::from_str(
         r#"{
             "type":"decision",
-            "id":1,
+            "id":"1",
             "name":"complex_nested",
-            "fallbacks":[
-                0
-            ],
+            "fallbacks":[ "0" ],
             "results":{
-                "100":[
-                    1
-                ],
-                "300":[
-                    2
-                ]
+                "100":[ "1" ],
+                "300":[ "2" ]
             },
             "expressions":[
             {
-                "id":100,
+                "id":"100",
                 "type":"comparison",
                 "operator":"equals",
                 "operands":[
@@ -50,17 +44,17 @@ fn test_decision_complex_nested_all_passed() {
                 ]
             },
             {
-                "id":300,
+                "id":"300",
                 "type":"logical",
                 "operator":"and",
                 "expressions":[
                 {
-                    "id":301,
+                    "id":"301",
                     "type":"logical",
                     "operator":"and",
                     "expressions":[
                     {
-                        "id":302,
+                        "id":"302",
                         "type":"comparison",
                         "operator":"greater_than",
                         "operands":[
@@ -75,7 +69,7 @@ fn test_decision_complex_nested_all_passed() {
                         ]
                     },
                     {
-                        "id":303,
+                        "id":"303",
                         "type":"comparison",
                         "operator":"less_than",
                         "operands":[
@@ -90,7 +84,7 @@ fn test_decision_complex_nested_all_passed() {
                         ]
                     },
                     {
-                        "id":304,
+                        "id":"304",
                         "type":"comparison",
                         "operator":"equals",
                         "operands":[
@@ -105,18 +99,18 @@ fn test_decision_complex_nested_all_passed() {
                         ]
                     },
                     {
-                        "id": 305,
+                        "id": "305",
                         "type": "logical",
                         "operator": "or",
                         "expressions": [
                         {
-                            "id": 306,
+                            "id": "306",
                             "type": "comparison",
                             "operator": "equals",
                             "operands": [
                             {
                                 "type": "data",
-                                "id": 11,
+                                "id": "11",
                                 "name": "first_value",
                                 "path": "/first_value"
                             },
@@ -127,13 +121,13 @@ fn test_decision_complex_nested_all_passed() {
                             ]
                         },
                         {
-                            "id": 307,
+                            "id": "307",
                             "type": "comparison",
                             "operator": "equals",
                             "operands": [
                             {
                                 "type": "data",
-                                "id": 13,
+                                "id": "13",
                                 "name": "second_value",
                                 "path": "/second_value"
                             },
@@ -148,12 +142,12 @@ fn test_decision_complex_nested_all_passed() {
                     ]
                 },
                 {
-                    "id":304,
+                    "id":"304",
                     "type":"logical",
                     "operator":"or",
                     "expressions":[
                     {
-                        "id":305,
+                        "id":"305",
                         "type":"comparison",
                         "operator":"greater_than",
                         "operands":[
@@ -168,12 +162,12 @@ fn test_decision_complex_nested_all_passed() {
                         ]
                     },
                     {
-                        "id":306,
+                        "id":"306",
                         "type":"logical",
                         "operator":"and",
                         "expressions":[
                         {
-                            "id":307,
+                            "id":"307",
                             "type":"comparison",
                             "operator":"less_than",
                             "operands":[
@@ -188,7 +182,7 @@ fn test_decision_complex_nested_all_passed() {
                             ]
                         },
                         {
-                            "id":308,
+                            "id":"308",
                             "type":"comparison",
                             "operator":"greater_than",
                             "operands":[
@@ -219,7 +213,7 @@ fn test_decision_complex_nested_all_passed() {
     let condition = Condition::try_from(definition).unwrap();
     assert!(condition.validate().is_ok());
     let result = condition.evaluate(&context).unwrap();
-    assert_eq!(result, vec![1, 2]);
+    assert_eq!(result, vec!["1", "2"]);
 }
 
 #[test]
@@ -232,20 +226,14 @@ fn test_decision_complex_nested_some_pass() {
 
     let definition = json!({
         "type":"decision",
-        "fallbacks":[
-            0
-        ],
+        "fallbacks":[ "0" ],
         "results":{
-            "100":[
-                1
-            ],
-            "300":[
-                2
-            ]
+            "100":[ "1" ],
+            "300":[ "2" ]
         },
         "expressions":[
         {
-            "id":100,
+            "id":"100",
             "type":"comparison",
             "operator":"equals",
             "operands":[
@@ -260,17 +248,17 @@ fn test_decision_complex_nested_some_pass() {
             ]
         },
         {
-            "id":300,
+            "id":"300",
             "type":"logical",
             "operator":"and",
             "expressions":[
             {
-                "id":301,
+                "id":"301",
                 "type":"logical",
                 "operator":"and",
                 "expressions":[
                 {
-                    "id":302,
+                    "id":"302",
                     "type":"comparison",
                     "operator":"greater_than",
                     "operands":[
@@ -285,7 +273,7 @@ fn test_decision_complex_nested_some_pass() {
                     ]
                 },
                 {
-                    "id":303,
+                    "id":"303",
                     "type":"comparison",
                     "operator":"less_than",
                     "operands":[
@@ -302,12 +290,12 @@ fn test_decision_complex_nested_some_pass() {
                 ]
             },
             {
-                "id":304,
+                "id":"304",
                 "type":"logical",
                 "operator":"or",
                 "expressions":[
                 {
-                    "id":305,
+                    "id":"305",
                     "type":"comparison",
                     "operator":"greater_than",
                     "operands":[
@@ -322,12 +310,12 @@ fn test_decision_complex_nested_some_pass() {
                     ]
                 },
                 {
-                    "id":306,
+                    "id":"306",
                     "type":"logical",
                     "operator":"and",
                     "expressions":[
                     {
-                        "id":307,
+                        "id":"307",
                         "type":"comparison",
                         "operator":"less_than",
                         "operands":[
@@ -342,7 +330,7 @@ fn test_decision_complex_nested_some_pass() {
                         ]
                     },
                     {
-                        "id":308,
+                        "id":"308",
                         "type":"comparison",
                         "operator":"greater_than",
                         "operands":[
@@ -367,7 +355,7 @@ fn test_decision_complex_nested_some_pass() {
 
     let condition = Condition::try_from(definition).unwrap();
     let result = condition.evaluate(&context).unwrap();
-    assert_eq!(result, vec![1]);
+    assert_eq!(result, vec!["1"]);
 }
 
 #[test]
@@ -380,20 +368,14 @@ fn test_decision_fallback() {
 
     let definition = json!({
         "type":"decision",
-        "fallbacks":[
-            0
-        ],
+        "fallbacks":[ "0" ],
         "results":{
-            "100":[
-                1
-            ],
-            "300":[
-                2
-            ]
+            "100":[ "1" ],
+            "300":[ "2" ],
         },
         "expressions":[
         {
-            "id":100,
+            "id":"100",
             "type":"comparison",
             "operator":"equals",
             "operands":[
@@ -408,17 +390,17 @@ fn test_decision_fallback() {
             ]
         },
         {
-            "id":300,
+            "id":"300",
             "type":"logical",
             "operator":"and",
             "expressions":[
             {
-                "id":301,
+                "id":"301",
                 "type":"logical",
                 "operator":"and",
                 "expressions":[
                 {
-                    "id":302,
+                    "id":"302",
                     "type":"comparison",
                     "operator":"greater_than",
                     "operands":[
@@ -433,7 +415,7 @@ fn test_decision_fallback() {
                     ]
                 },
                 {
-                    "id":303,
+                    "id":"303",
                     "type":"comparison",
                     "operator":"less_than",
                     "operands":[
@@ -450,12 +432,12 @@ fn test_decision_fallback() {
                 ]
             },
             {
-                "id":304,
+                "id":"304",
                 "type":"logical",
                 "operator":"or",
                 "expressions":[
                 {
-                    "id":305,
+                    "id":"305",
                     "type":"comparison",
                     "operator":"greater_than",
                     "operands":[
@@ -470,12 +452,12 @@ fn test_decision_fallback() {
                     ]
                 },
                 {
-                    "id":306,
+                    "id":"306",
                     "type":"logical",
                     "operator":"and",
                     "expressions":[
                     {
-                        "id":307,
+                        "id":"307",
                         "type":"comparison",
                         "operator":"less_than",
                         "operands":[
@@ -490,7 +472,7 @@ fn test_decision_fallback() {
                         ]
                     },
                     {
-                        "id":308,
+                        "id":"308",
                         "type":"comparison",
                         "operator":"greater_than",
                         "operands":[
@@ -515,7 +497,7 @@ fn test_decision_fallback() {
 
     let condition = Condition::try_from(definition).unwrap();
     let result = condition.evaluate(&context).unwrap();
-    assert_eq!(result, vec![0]);
+    assert_eq!(result, vec!["0"]);
 }
 
 #[test]
@@ -528,22 +510,20 @@ fn test_binary() {
 
     let definition = json!({
         "type":"binary",
-        "fallbacks":[
-            0
-        ],
-        "results": [ 1 ],
+        "fallbacks":[ "0" ],
+        "results": [ "1" ],
         "expression":{
-            "id":300,
+            "id":"300",
             "type":"logical",
             "operator":"and",
             "expressions":[
             {
-                "id":301,
+                "id":"301",
                 "type":"logical",
                 "operator":"and",
                 "expressions":[
                 {
-                    "id":302,
+                    "id":"302",
                     "type":"comparison",
                     "operator":"greater_than",
                     "operands":[
@@ -558,7 +538,7 @@ fn test_binary() {
                     ]
                 },
                 {
-                    "id":303,
+                    "id":"303",
                     "type":"comparison",
                     "operator":"less_than",
                     "operands":[
@@ -575,12 +555,12 @@ fn test_binary() {
                 ]
             },
             {
-                "id":304,
+                "id":"304",
                 "type":"logical",
                 "operator":"or",
                 "expressions":[
                 {
-                    "id":305,
+                    "id":"305",
                     "type":"comparison",
                     "operator":"greater_than",
                     "operands":[
@@ -595,12 +575,12 @@ fn test_binary() {
                     ]
                 },
                 {
-                    "id":306,
+                    "id":"306",
                     "type":"logical",
                     "operator":"and",
                     "expressions":[
                     {
-                        "id":307,
+                        "id":"307",
                         "type":"comparison",
                         "operator":"less_than",
                         "operands":[
@@ -615,7 +595,7 @@ fn test_binary() {
                         ]
                     },
                     {
-                        "id":308,
+                        "id":"308",
                         "type":"comparison",
                         "operator":"greater_than",
                         "operands":[
@@ -640,7 +620,7 @@ fn test_binary() {
     let condition = Condition::try_from(definition).unwrap();
     assert!(condition.validate().is_ok());
     let result = condition.evaluate(&context).unwrap();
-    assert_eq!(result, vec![1]);
+    assert_eq!(result, vec!["1"]);
 }
 
 #[test]
@@ -653,20 +633,20 @@ fn test_binary_fallback() {
 
     let definition = json!({
         "type":"binary",
-        "fallbacks":[ 0 ],
-        "results": [ 1, 2 ],
+        "fallbacks":[ "0" ],
+        "results": [ "1", "2" ],
         "expression":{
-            "id":300,
+            "id":"300",
             "type":"logical",
             "operator":"and",
             "expressions":[
             {
-                "id":301,
+                "id":"301",
                 "type":"logical",
                 "operator":"and",
                 "expressions":[
                 {
-                    "id":302,
+                    "id":"302",
                     "type":"comparison",
                     "operator":"greater_than",
                     "operands":[
@@ -681,7 +661,7 @@ fn test_binary_fallback() {
                     ]
                 },
                 {
-                    "id":303,
+                    "id":"303",
                     "type":"comparison",
                     "operator":"less_than",
                     "operands":[
@@ -698,12 +678,12 @@ fn test_binary_fallback() {
                 ]
             },
             {
-                "id":304,
+                "id":"304",
                 "type":"logical",
                 "operator":"or",
                 "expressions":[
                 {
-                    "id":305,
+                    "id":"305",
                     "type":"comparison",
                     "operator":"greater_than",
                     "operands":[
@@ -718,12 +698,12 @@ fn test_binary_fallback() {
                     ]
                 },
                 {
-                    "id":306,
+                    "id":"306",
                     "type":"logical",
                     "operator":"and",
                     "expressions":[
                     {
-                        "id":307,
+                        "id":"307",
                         "type":"comparison",
                         "operator":"less_than",
                         "operands":[
@@ -738,7 +718,7 @@ fn test_binary_fallback() {
                         ]
                     },
                     {
-                        "id":308,
+                        "id":"308",
                         "type":"comparison",
                         "operator":"greater_than",
                         "operands":[
@@ -762,80 +742,80 @@ fn test_binary_fallback() {
 
     let condition = Condition::try_from(definition).unwrap();
     let result = condition.evaluate(&context).unwrap();
-    assert_eq!(result, vec![0]);
+    assert_eq!(result, vec!["0"]);
 }
 
 #[test]
 fn test_dependencies() {
     let definition = json!({
         "type": "decision",
-        "fallbacks": [0],
+        "fallbacks": [ "0" ],
         "results": {
-            "100": [1]
+            "100": [ "1" ]
         },
         "expressions": [
+        {
+            "id": "100",
+            "type": "comparison",
+            "operator": "greater_than_or_equal",
+            "operands": [
             {
-                "id": 100,
-                "type": "comparison",
-                "operator": "greater_than_or_equal",
-                "operands": [
-                    {
-                        "type": "data",
-                        "path": "/first_value"
-                    },
-                    {
-                        "type": "output",
-                        "path": "/output",
-                        "output_id": 14,
-                    }
-                ]
+                "type": "data",
+                "path": "/first_value"
+            },
+            {
+                "type": "output",
+                "path": "/output",
+                "output_id": "14"
             }
+            ]
+        }
         ]
     });
     let condition = Condition::try_from(definition).unwrap();
     let dependencies = condition.dependencies();
-    assert_eq!(dependencies, vec![14]);
+    assert_eq!(dependencies, vec!["14"]);
 }
 
 #[test]
 fn test_dependants() {
     let definition = json!({
         "type": "decision",
-        "fallbacks": [0],
+        "fallbacks": [ "0" ],
         "results": {
-            "100": [1]
+            "100": [ "1" ]
         },
         "expressions": [
+        {
+            "id": "100",
+            "type": "comparison",
+            "operator": "greater_than_or_equal",
+            "operands": [
             {
-                "id": 100,
-                "type": "comparison",
-                "operator": "greater_than_or_equal",
-                "operands": [
-                    {
-                        "type": "data",
-                        "path": "/first_value"
-                    },
-                    {
-                        "type": "output",
-                        "path": "/output",
-                        "output_id": 14,
-                    }
-                ]
+                "type": "data",
+                "path": "/first_value"
+            },
+            {
+                "type": "output",
+                "path": "/output",
+                "output_id": "14"
             }
+            ]
+        }
         ]
     });
     let condition = Condition::try_from(definition).unwrap();
     let dependants = condition.dependants();
-    assert_eq!(dependants, vec![0, 1]);
+    assert_eq!(dependants, vec!["0", "1"]);
 }
 
 #[test]
 fn test_expression_invalid_decision_expressions_empty() {
     let definition = json!({
         "type": "decision",
-        "fallbacks": [0],
+        "fallbacks": [ "0" ],
         "results": {
-            "100": [1]
+            "100": [ "1" ]
         },
         "expressions": []
     });
@@ -848,10 +828,10 @@ fn test_expression_invalid_decision_expressions_empty() {
 fn test_logical_child_missing() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": []
@@ -866,14 +846,14 @@ fn test_logical_child_missing() {
 fn test_logical_count_invalid() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": [{
-                "id": 302,
+                "id": "302",
                 "type": "comparison",
                 "operator": "greater_than",
                 "operands": [{
@@ -893,9 +873,9 @@ fn test_logical_count_invalid() {
 fn test_expression_invalid_decision_expressions_mismatch() {
     let definition = json!({
         "type": "decision",
-        "fallbacks": [0],
+        "fallbacks": [ "0" ],
         "results": {
-            "100": [1]
+            "100": [ "1" ]
         },
         "expressions": {}
     });
@@ -906,8 +886,8 @@ fn test_expression_invalid_decision_expressions_mismatch() {
 fn test_deserialize_binary_error_expression_type() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": []
     });
     assert_condition_deserialize_error!(definition);
@@ -917,8 +897,8 @@ fn test_deserialize_binary_error_expression_type() {
 fn test_deserialize_binary_error_expression_missing() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1]
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
     });
     assert_condition_deserialize_error!(definition);
 }
@@ -927,8 +907,8 @@ fn test_deserialize_binary_error_expression_missing() {
 fn test_deserialize_decision_error_expressions_mismatch() {
     let definition = json!({
         "type": "decision",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expressions": {}
     });
     assert_condition_deserialize_error!(definition);
@@ -938,8 +918,8 @@ fn test_deserialize_decision_error_expressions_mismatch() {
 fn test_deserialize_decision_error_expressions_missing() {
     let definition = json!({
         "type": "decision",
-        "fallbacks": [0],
-        "results": [1]
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
     });
     assert_condition_deserialize_error!(definition);
 }
@@ -948,8 +928,8 @@ fn test_deserialize_decision_error_expressions_missing() {
 fn test_deserialize_error_malformed() {
     let definition = json!({
         "type": "decision",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expressions": [],
     });
     assert_condition_deserialize_error!(definition);
@@ -959,8 +939,8 @@ fn test_deserialize_error_malformed() {
 fn test_deserialize_error_invalid_type() {
     let definition = json!({
         "type": "invalid",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expressions": [],
         "expression": {}
     });
@@ -972,7 +952,7 @@ fn test_deserialize_error_invalid_fallbacks() {
     let definition = json!({
         "type": "binary",
         "fallbacks": {},
-        "results": [1],
+        "results": [ "1" ],
         "expression": {}
     });
     assert_condition_deserialize_error!(definition);
@@ -982,7 +962,7 @@ fn test_deserialize_error_invalid_fallbacks() {
 fn test_deserialize_error_invalid_results() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
+        "fallbacks": [ "0" ],
         "results": {},
         "expression": {}
     });
@@ -993,10 +973,10 @@ fn test_deserialize_error_invalid_results() {
 fn test_deserialize_error_invalid_comparison_operator() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "comparison",
             "operator": "invalid",
             "operands": []
@@ -1009,10 +989,10 @@ fn test_deserialize_error_invalid_comparison_operator() {
 fn test_deserialize_error_invalid_comparison_operator_type() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "comparison",
             "operator": 1,
             "operands": []
@@ -1025,10 +1005,10 @@ fn test_deserialize_error_invalid_comparison_operator_type() {
 fn test_deserialize_error_invalid_comparison_operands_type() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "comparison",
             "operator": "greater_than",
             "operands": {}
@@ -1041,10 +1021,10 @@ fn test_deserialize_error_invalid_comparison_operands_type() {
 fn test_deserialize_error_invalid_logical_operator() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "invalid",
             "expressions": []
@@ -1057,10 +1037,10 @@ fn test_deserialize_error_invalid_logical_operator() {
 fn test_deserialize_error_invalid_logical_operator_type() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": 1,
             "expressions": []
@@ -1073,10 +1053,10 @@ fn test_deserialize_error_invalid_logical_operator_type() {
 fn test_deserialize_error_invalid_logical_expressions_type() {
     let definition = json!({
         "type": "binary",
-        "fallbacks": [0],
-        "results": [1],
+        "fallbacks": [ "0" ],
+        "results": [ "1" ],
         "expression": {
-            "id": 300,
+            "id": "300",
             "type": "logical",
             "operator": "and",
             "expressions": {}

--- a/crates/ruline-context/src/lib.rs
+++ b/crates/ruline-context/src/lib.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 #[derive(Debug)]
 pub struct Context {
     pub data: Value,
-    pub outputs: DashMap<i64, Value>,
+    pub outputs: DashMap<String, Value>,
     pub variables: DashMap<String, Value>,
 }
 
@@ -17,7 +17,7 @@ impl Context {
         }
     }
 
-    pub fn set_output(&self, id: i64, value: Value) {
+    pub fn set_output(&self, id: String, value: Value) {
         self.outputs.insert(id, value);
     }
 
@@ -25,12 +25,12 @@ impl Context {
         self.data.pointer(key).cloned()
     }
 
-    pub fn get_output(&self, id: i64, key: &str) -> Option<Value> {
-        self.outputs.get(&id).and_then(|v| v.pointer(key).cloned())
+    pub fn get_output(&self, id: &str, key: &str) -> Option<Value> {
+        self.outputs.get(id).and_then(|v| v.pointer(key).cloned())
     }
 
     pub fn get_variable(&self, key: &str) -> Option<Value> {
-        self.variables.get(key).map(|v| v.value().clone())
+        self.variables.get(key).map(|v| v.value().to_owned())
     }
 
     pub fn set_variable(&self, key: String, value: Value) {

--- a/crates/ruline-field/src/error.rs
+++ b/crates/ruline-field/src/error.rs
@@ -20,7 +20,7 @@ pub enum FieldError {
             "`{}` in output `{}` not found",
             path, output_id
         ),
-        _ => "Value not found".to_string(),
+        _ => "Value not found".to_owned(),
     })]
     FieldNotFound(FieldDefinition),
     #[error(transparent)]

--- a/crates/ruline-field/src/function/func.rs
+++ b/crates/ruline-field/src/function/func.rs
@@ -219,18 +219,18 @@ pub fn join(args: Vec<Value>) -> Result<Value> {
     validate_min_args!(args, 2);
 
     let separator = match &args[0] {
-        Value::String(s) => s.clone(),
+        Value::String(s) => s.to_owned(),
         _ => return Err(FunctionError::ArgumentTypeInvalid.into()),
     };
 
     let mut values = vec![];
     for arg in args.iter().skip(1) {
         match arg {
-            Value::String(s) => values.push(s.clone()),
+            Value::String(s) => values.push(s.to_owned()),
             Value::Array(arr) => {
                 for value in arr {
                     match value {
-                        Value::String(s) => values.push(s.clone()),
+                        Value::String(s) => values.push(s.to_owned()),
                         _ => return Err(FunctionError::ArgumentTypeInvalid.into()),
                     }
                 }

--- a/crates/ruline-field/tests/field.rs
+++ b/crates/ruline-field/tests/field.rs
@@ -39,7 +39,7 @@ fn test_get_data_field_not_found() {
 fn test_get_output_field() {
     let context = Context::new(json!({}), DashMap::new());
     context.set_output(
-        30,
+        "30".to_string(),
         json!({
             "foo": {
                 "bar": {
@@ -51,7 +51,7 @@ fn test_get_output_field() {
 
     let definition = json!({
         "type": "output",
-        "output_id": 30,
+        "output_id": "30",
         "path": "/foo/bar/baz"
     });
 
@@ -62,7 +62,7 @@ fn test_get_output_field() {
 fn test_get_output_field_not_found() {
     assert_field_error!({
         "type": "output",
-        "output_id": 30,
+        "output_id": "30",
         "path": "/foo/bar/baz"
     });
 }

--- a/crates/ruline-field/tests/function.rs
+++ b/crates/ruline-field/tests/function.rs
@@ -76,7 +76,7 @@ fn test_function_field_dependencies() {
                 "args": [
                 {
                     "type": "output",
-                    "output_id": 10,
+                    "output_id": "10",
                     "path": "/foo/bar/baz"
                 },
                 {
@@ -85,7 +85,7 @@ fn test_function_field_dependencies() {
                     "args": [
                     {
                         "type": "output",
-                        "output_id": 20,
+                        "output_id": "20",
                         "path": "/foo/bar/baz"
                     },
                     {
@@ -102,7 +102,7 @@ fn test_function_field_dependencies() {
                 "args": [
                 {
                     "type": "output",
-                    "output_id": 40,
+                    "output_id": "40",
                     "path": "/foo/bar/baz"
                 },
                 {
@@ -117,7 +117,7 @@ fn test_function_field_dependencies() {
 
     let field = Field::try_from(definition).unwrap();
     let dependencies = field.dependencies();
-    assert_eq!(dependencies, vec![10, 20, 40]);
+    assert_eq!(dependencies, vec!["10", "20", "40"]);
 }
 
 #[test]

--- a/crates/ruline-output/src/lib.rs
+++ b/crates/ruline-output/src/lib.rs
@@ -22,7 +22,7 @@ impl Output {
         let mut output = HashMap::new();
 
         for (key, value) in &self.definition.0 {
-            output.insert(key.clone(), Field::from(value).process(ctx)?);
+            output.insert(key.to_owned(), Field::from(value).process(ctx)?);
         }
         Ok(serde_json::to_value(output)?)
     }

--- a/crates/ruline-workflow/src/error.rs
+++ b/crates/ruline-workflow/src/error.rs
@@ -6,9 +6,15 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum WorkflowError {
     #[error("Dependency `{dependency}` for component `{component_id}` not found")]
-    DependencyNotFound { component_id: i64, dependency: i64 },
+    DependencyNotFound {
+        component_id: String,
+        dependency: String,
+    },
     #[error("Dependant `{dependant}` for component `{component_id}` not found")]
-    DependantNotFound { component_id: i64, dependant: i64 },
+    DependantNotFound {
+        component_id: String,
+        dependant: String,
+    },
 
     #[error("Cycle detected")]
     CycleDetected,

--- a/crates/ruline-workflow/tests/workflow.rs
+++ b/crates/ruline-workflow/tests/workflow.rs
@@ -24,18 +24,18 @@ fn test_workflow() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            3
+                            "3"
                         ],
                         "results": [
-                            4
+                            "4"
                         ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "not_exists",
                                 "operands": [
@@ -46,7 +46,7 @@ fn test_workflow() {
                                 ]
                             },
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "not_exists",
                                 "operands": [
@@ -66,18 +66,18 @@ fn test_workflow() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            3
+                            "3"
                         ],
                         "results": [
-                            3
+                            "3"
                         ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "exists",
                                 "operands": [
@@ -88,7 +88,7 @@ fn test_workflow() {
                                 ]
                             },
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "exists",
                                 "operands": [
@@ -110,12 +110,12 @@ fn test_workflow() {
                         "fallbacks": [],
                         "results": [],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "equals",
                                 "operands": [
@@ -130,7 +130,7 @@ fn test_workflow() {
                                 ]
                             },
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "equals",
                                 "operands": [
@@ -154,19 +154,19 @@ fn test_workflow() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            6
+                            "6"
                         ],
                         "results": [
-                            5,
-                            6
+                            "5",
+                            "6"
                         ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "not_equals",
                                 "operands": [
@@ -181,7 +181,7 @@ fn test_workflow() {
                                 ]
                             },
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "not_equals",
                                 "operands": [
@@ -204,18 +204,18 @@ fn test_workflow() {
                     "name": "gt_test",
                     "definition": {
                         "type": "binary",
-                        "id": 5,
+                        "id": "5",
                         "fallbacks": [],
                         "results": [
-                            6
+                            "6"
                         ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "greater_than",
                                 "operands": [
@@ -230,7 +230,7 @@ fn test_workflow() {
                                 ]
                             },
                             {
-                                "id": 102,
+                                "id": "102",
                                 "type": "comparison",
                                 "operator": "greater_than",
                                 "operands": [
@@ -252,21 +252,21 @@ fn test_workflow() {
                     "type": "condition",
                     "name": "gte_test",
                     "definition": {
-                        "id": 100,
+                        "id": "100",
                         "type": "binary",
                         "fallbacks": [
-                            8
+                            "8"
                         ],
                         "results": [
-                            7
+                            "7"
                         ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "greater_than_or_equal",
                                 "operands": [
@@ -281,7 +281,7 @@ fn test_workflow() {
                                 ]
                             },
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "greater_than_or_equal",
                                 "operands": [
@@ -365,24 +365,24 @@ fn test_cyclic_workflow() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            2
+                            "2"
                         ],
                         "results": [
-                            3
+                            "3"
                         ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 3
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 3
+                            }
                             ]
                         }
                     }
@@ -393,24 +393,24 @@ fn test_cyclic_workflow() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            1
+                            "1"
                         ],
                         "results": [
-                            3
+                            "3"
                         ],
                         "expression": {
-                            "id": 101,
+                            "id": "101",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 5
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 5
+                            }
                             ]
                         }
                     }
@@ -421,27 +421,27 @@ fn test_cyclic_workflow() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            1
+                            "1"
                         ],
                         "results": [
-                            1
+                            "1"
                         ],
                         "expression": {
-                            "id": 102,
+                            "id": "102",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
+                            {
+                                "id": "100",
+                                "type": "comparison",
+                                "operator": "exists",
+                                "operands": [
                                 {
-                                    "id": 100,
-                                    "type": "comparison",
-                                    "operator": "exists",
-                                    "operands": [
-                                        {
-                                            "type": "variable",
-                                            "variable": "counter"
-                                        }
-                                    ]
+                                    "type": "variable",
+                                    "variable": "counter"
                                 }
+                                ]
+                            }
                             ]
                         }
                     }
@@ -452,7 +452,7 @@ fn test_cyclic_workflow() {
                 "counter": 0
             }
         }
-        "#,
+    "#,
     );
     deserializer.disable_recursion_limit();
     let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
@@ -475,24 +475,24 @@ fn test_workflow_missing_variables() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            2
+                            "2"
                         ],
                         "results": [
-                            3
+                            "3"
                         ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 3
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 3
+                            }
                             ]
                         }
                     }
@@ -503,24 +503,24 @@ fn test_workflow_missing_variables() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            1
+                            "1"
                         ],
                         "results": [
-                            3
+                            "3"
                         ],
                         "expression": {
-                            "id": 101,
+                            "id": "101",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 5
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 5
+                            }
                             ]
                         }
                     }
@@ -531,27 +531,27 @@ fn test_workflow_missing_variables() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [
-                            1
+                            "1"
                         ],
                         "results": [
-                            1
+                            "1"
                         ],
                         "expression": {
-                            "id": 102,
+                            "id": "102",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
+                            {
+                                "id": "100",
+                                "type": "comparison",
+                                "operator": "exists",
+                                "operands": [
                                 {
-                                    "id": 100,
-                                    "type": "comparison",
-                                    "operator": "exists",
-                                    "operands": [
-                                        {
-                                            "type": "variable",
-                                            "variable": "counter"
-                                        }
-                                    ]
+                                    "type": "variable",
+                                    "variable": "counter"
                                 }
+                                ]
+                            }
                             ]
                         }
                     }
@@ -559,7 +559,7 @@ fn test_workflow_missing_variables() {
             },
             "output": {}
         }
-        "#,
+    "#,
     );
     deserializer.disable_recursion_limit();
     let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
@@ -579,25 +579,21 @@ fn test_workflow_components_malformed() {
                     "name": "check_counter_less_than_3",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            2
-                        ],
-                        "results": [
-                            3
-                        ],
+                        "fallbacks": [ "2" ],
+                        "results": [ "3" ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 3
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 3
+                            }
                             ]
                         }
                     }
@@ -608,7 +604,7 @@ fn test_workflow_components_malformed() {
                 "counter": 0
             }
         }
-        "#,
+    "#,
     );
     deserializer.disable_recursion_limit();
     let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
@@ -628,25 +624,21 @@ fn test_workflow_output_malformed() {
                     "name": "check_counter_less_than_3",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            2
-                        ],
-                        "results": [
-                            3
-                        ],
+                        "fallbacks": [ "2" ],
+                        "results": [ "3" ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 3
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 3
+                            }
                             ]
                         }
                     }
@@ -656,25 +648,21 @@ fn test_workflow_output_malformed() {
                     "name": "check_counter_less_than_5",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            1
-                        ],
-                        "results": [
-                            3
-                        ],
+                        "fallbacks": [ "1" ],
+                        "results": [ "3" ],
                         "expression": {
-                            "id": 101,
+                            "id": "101",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 5
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 5
+                            }
                             ]
                         }
                     }
@@ -684,28 +672,24 @@ fn test_workflow_output_malformed() {
                     "name": "increment_counter",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            1
-                        ],
-                        "results": [
-                            1
-                        ],
+                        "fallbacks": [ "1" ],
+                        "results": [ "1" ],
                         "expression": {
-                            "id": 102,
+                            "id": "102",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
+                            {
+                                "id": "100",
+                                "type": "comparison",
+                                "operator": "exists",
+                                "operands": [
                                 {
-                                    "id": 100,
-                                    "type": "comparison",
-                                    "operator": "exists",
-                                    "operands": [
-                                        {
-                                            "type": "variable",
-                                            "variable": "counter"
-                                        }
-                                    ]
+                                    "type": "variable",
+                                    "variable": "counter"
                                 }
+                                ]
+                            }
                             ]
                         }
                     }
@@ -718,7 +702,7 @@ fn test_workflow_output_malformed() {
                 "counter": 0
             }
         }
-        "#,
+    "#,
     );
     deserializer.disable_recursion_limit();
     let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
@@ -737,25 +721,21 @@ fn test_workflow_component_name_missing() {
                     "type": "condition",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            2
-                        ],
-                        "results": [
-                            3
-                        ],
+                        "fallbacks": [ "2" ],
+                        "results": [ "3" ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 3
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 3
+                            }
                             ]
                         }
                     }
@@ -764,25 +744,21 @@ fn test_workflow_component_name_missing() {
                     "type": "condition",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            1
-                        ],
-                        "results": [
-                            3
-                        ],
+                        "fallbacks": [ "1" ],
+                        "results": [ "3" ],
                         "expression": {
-                            "id": 101,
+                            "id": "101",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 5
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 5
+                            }
                             ]
                         }
                     }
@@ -791,28 +767,24 @@ fn test_workflow_component_name_missing() {
                     "type": "condition",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            1
-                        ],
-                        "results": [
-                            1
-                        ],
+                        "fallbacks": [ "1" ],
+                        "results": [ "1" ],
                         "expression": {
-                            "id": 102,
+                            "id": "102",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
+                            {
+                                "id": "100",
+                                "type": "comparison",
+                                "operator": "exists",
+                                "operands": [
                                 {
-                                    "id": 100,
-                                    "type": "comparison",
-                                    "operator": "exists",
-                                    "operands": [
-                                        {
-                                            "type": "variable",
-                                            "variable": "counter"
-                                        }
-                                    ]
+                                    "type": "variable",
+                                    "variable": "counter"
                                 }
+                                ]
+                            }
                             ]
                         }
                     }
@@ -823,7 +795,7 @@ fn test_workflow_component_name_missing() {
                 "counter": 0
             }
         }
-        "#,
+    "#,
     );
     deserializer.disable_recursion_limit();
     let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
@@ -843,19 +815,15 @@ fn test_workflow_component_dependency_not_found() {
                     "name": "component_1",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            3
-                        ],
-                        "results": [
-                            4
-                        ],
+                        "fallbacks": [ "3" ],
+                        "results": [ "4" ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "not_exists",
                                 "operands": [
@@ -866,7 +834,7 @@ fn test_workflow_component_dependency_not_found() {
                                 ]
                             },
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "not_exists",
                                 "operands": [
@@ -885,19 +853,15 @@ fn test_workflow_component_dependency_not_found() {
                     "name": "component_2",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            3
-                        ],
-                        "results": [
-                            3
-                        ],
+                        "fallbacks": [ "3" ],
+                        "results": [ "3" ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "exists",
                                 "operands": [
@@ -908,7 +872,7 @@ fn test_workflow_component_dependency_not_found() {
                                 ]
                             },
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "exists",
                                 "operands": [
@@ -930,12 +894,12 @@ fn test_workflow_component_dependency_not_found() {
                         "fallbacks": [],
                         "results": [],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "equals",
                                 "operands": [
@@ -950,7 +914,7 @@ fn test_workflow_component_dependency_not_found() {
                                 ]
                             },
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "equals",
                                 "operands": [
@@ -974,16 +938,14 @@ fn test_workflow_component_dependency_not_found() {
                     "definition": {
                         "type": "binary",
                         "fallbacks": [],
-                        "results": [
-                            5
-                        ],
+                        "results": [ "5" ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "not_equals",
                                 "operands": [
@@ -998,7 +960,7 @@ fn test_workflow_component_dependency_not_found() {
                                 ]
                             },
                             {
-                                "id": 100,
+                                "id": "100",
                                 "type": "comparison",
                                 "operator": "not_equals",
                                 "operands": [
@@ -1021,18 +983,16 @@ fn test_workflow_component_dependency_not_found() {
                     "name": "gt_test",
                     "definition": {
                         "type": "binary",
-                        "id": 5,
+                        "id": "5",
                         "fallbacks": [],
-                        "results": [
-                            6
-                        ],
+                        "results": [ "6" ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "logical",
                             "operator": "and",
                             "expressions": [
                             {
-                                "id": 101,
+                                "id": "101",
                                 "type": "comparison",
                                 "operator": "greater_than",
                                 "operands": [
@@ -1047,7 +1007,7 @@ fn test_workflow_component_dependency_not_found() {
                                 ]
                             },
                             {
-                                "id": 102,
+                                "id": "102",
                                 "type": "comparison",
                                 "operator": "greater_than",
                                 "operands": [
@@ -1108,7 +1068,7 @@ fn test_workflow_component_missing_definition() {
             }
         }
 
-    "#,
+        "#,
     );
     deserializer.disable_recursion_limit();
     let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
@@ -1127,25 +1087,21 @@ fn test_workflow_component_missing_type() {
                     "name": "component_1",
                     "definition": {
                         "type": "binary",
-                        "fallbacks": [
-                            2
-                        ],
-                        "results": [
-                            3
-                        ],
+                        "fallbacks": [ "2" ],
+                        "results": [ "3" ],
                         "expression": {
-                            "id": 100,
+                            "id": "100",
                             "type": "comparison",
                             "operator": "less_than",
                             "operands": [
-                                {
-                                    "type": "variable",
-                                    "variable": "counter"
-                                },
-                                {
-                                    "type": "value",
-                                    "value": 3
-                                }
+                            {
+                                "type": "variable",
+                                "variable": "counter"
+                            },
+                            {
+                                "type": "value",
+                                "value": 3
+                            }
                             ]
                         }
                     }


### PR DESCRIPTION
### Refactor
- Change the ids from `i64` to `String`.
- Change clones and `to_string` to `to_owned`.